### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/admission/views.py
+++ b/admission/views.py
@@ -5,5 +5,5 @@ import datetime
 # Create your views here.
 def current_datetime(request):
     now = datetime.datetime.now()
-    html = "<html><body>It is now %s.</body></html>" % now
+    html = "<html><body>It is now {0!s}.</body></html>".format(now)
     return HttpResponse(html)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:TheSundar:Edulys_admission?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:TheSundar:Edulys_admission?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)